### PR TITLE
CSS Modules does not work. #298

### DIFF
--- a/webpack.config.react4xp.js
+++ b/webpack.config.react4xp.js
@@ -35,7 +35,8 @@ module.exports = function(env, config) {
 					loader: 'css-loader',
 					options: {
 						importLoaders: 1,
-						modules: { auto: true }
+						modules: { auto: true },
+						esModule: false,
 					}
 				},
 				{


### PR DESCRIPTION
Add esModule: false to webpack.config.react4xp.js so css modules can be used.