### PR TITLE
Update build chapter #695

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     //include "com.enonic.xp:lib-websocket:${xpVersion}"
 
     // The version numbers must be here (or dependabot will fail)
-    include 'com.enonic.lib:lib-asset:1.0.1'
+    include 'com.enonic.lib:lib-asset:1.0.3'
     include 'com.enonic.lib:lib-thymeleaf:2.1.1'
     include 'com.enonic.lib:lib-guillotine:6.2.1'
     include 'com.enonic.lib:lib-react4xp:6.0.0-RC3'

--- a/docs/appendix/build.adoc
+++ b/docs/appendix/build.adoc
@@ -6,21 +6,36 @@
 == Build arguments
 
 [[NODE_ENV]]
-=== Development mode
+=== Development build
 
-Use the gradle commandline flag `-Pdev` or `-Pdevelopment` to enable building in development mode.
+To run a continuous build in development mode where assets are compiled for easy readability without minifying, making errors easier to track down run:
 
 [source,bash]
 ----
-enonic project gradle build deploy -Pdev
+enonic dev
 ----
 
-This switches between React4xp *build* modes (not to be confused with XP's https://developer.enonic.com/docs/enonic-cli/stable/dev#start[run modes]).
+=== Production build
 
-- `production`: assets are compiled more compact (and faster), with source maps
-- `development`: assets are compiled for more human-readability, without minification, making errors easier to track down.
+To make a production build where hashed assets are compiled compact, fast with source maps.
+Since production build is default, you can run:
 
-Default value is `production`.
+[source,bash]
+----
+enonic project build
+----
+
+This gives you a production build with an application ready to use for your server.
+
+=== Running production builds locally
+
+If you want to test a production build locally, you need to start your sandbox in production (as well as the project).
+This allows you to serve the optimized assets with hashing and cached headers locally:
+
+[source,bash]
+----
+enonic sandbox start --prod
+----
 
 [[VERBOSE]]
 === Verbosity

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@enonic-types/global": "^7.15.0",
         "@enonic-types/lib-admin": "^7.15.0",
         "@enonic-types/lib-app": "^7.15.0",
-        "@enonic-types/lib-asset": "^1.0.1",
+        "@enonic-types/lib-asset": "^1.0.3",
         "@enonic-types/lib-auditlog": "^7.15.0",
         "@enonic-types/lib-auth": "^7.15.0",
         "@enonic-types/lib-cluster": "^7.15.0",
@@ -1825,9 +1825,9 @@
       }
     },
     "node_modules/@enonic-types/lib-asset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@enonic-types/lib-asset/-/lib-asset-1.0.2.tgz",
-      "integrity": "sha512-k6RNfKMuCpjCzDEFjQPGz253CBFMjxEKPMyisbZpaEGabHDo9ZBTuiL5upWQPoKcWkssbUw5LE037SV+dZiMfw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@enonic-types/lib-asset/-/lib-asset-1.0.3.tgz",
+      "integrity": "sha512-fmjSSJAAh98es7dUVCFtJIklYngWbgjfAVSm+wCqnrCbjD15tLZJ9BlP7UaeP4amytppVcWyy04pBeJStL0nWQ==",
       "dev": true,
       "dependencies": {
         "@enonic-types/core": "^7.14.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@enonic-types/global": "^7.15.0",
     "@enonic-types/lib-admin": "^7.15.0",
     "@enonic-types/lib-app": "^7.15.0",
-    "@enonic-types/lib-asset": "^1.0.1",
+    "@enonic-types/lib-asset": "^1.0.3",
     "@enonic-types/lib-auditlog": "^7.15.0",
     "@enonic-types/lib-auth": "^7.15.0",
     "@enonic-types/lib-cluster": "^7.15.0",


### PR DESCRIPTION
Update build chapter to reflect actual build commands. No need to use -Penv=dev/prod as end users can use enonic dev and enonic project build / deploy Sandbox need to be set to production to test in a true production environment. Clarify commands and results of commands.
Update lib asset to 1.0.3