### PR TITLE
404 handling doesn't work with vhost enabled

### DIFF
--- a/src/main/resources/react4xp/utils/requestUtils.ts
+++ b/src/main/resources/react4xp/utils/requestUtils.ts
@@ -1,12 +1,13 @@
 import type {Request, Response, Component} from '@enonic-types/core';
 import {getUser} from '/lib/xp/auth';
 import {Content, get as getContentByKey, exists} from '/lib/xp/content';
-import {pageUrl, getContent} from '/lib/xp/portal';
+import {pageUrl, getContent, getSite} from '/lib/xp/portal';
 import {get as getContext, run as runContext} from '/lib/xp/context';
 import {getIn} from '@enonic/js-utils/object/getIn';
 
 export function handlePermissions(request: Request): Response {
-    if (isContentExists(getContentPath(request))) {
+    const path = getContentPath(request);
+    if (path && isContentExists(path)) {
 
         if (!getUser()) {
             return newResponse({
@@ -63,12 +64,24 @@ export function jsonError(text: string, status: number = 400): Response {
 
 }
 
-export function getContentPath(request): string {
-    const basePath = request.contextPath.substring(0, request.contextPath.lastIndexOf('/'));
-    return request.path.substring(basePath.length);
+export function getContentPath(request: Request): string {
+    const site = getSite();
+    if (!site) {
+        return request.path;
+    }
+
+    const siteBase = pageUrl({path: site._path}).replace(/\/+$/, '');
+    const tail = request.path.indexOf(siteBase) === 0
+        ? request.path.substring(siteBase.length)
+        : request.path;
+
+    return (site._path + tail).replace(/\/+$/, '') || '/';
 }
 
 function isContentExists(path: string): boolean {
+    if (!path) {
+        return false;
+    }
     const {repository, branch} = getContext();
     return runContext({
         repository,


### PR DESCRIPTION
Closes #974

A site is reachable at different URL bases depending on how it is served:
- Content Studio preview: `/admin/site/preview/<project>/<branch>/<sitePath>`
- direct site engine:     `/site/<project>/<branch>/<sitePath>`
- vhost mapping:          e.g. `/` (root) or `/any/custom/base`

`request.contextPath` lives in the *internal* address space and, for a missing content, resolves to the nearest existing ancestor - so it cannot be turned into the requested content path by string math against `request.path` (they may not even share a prefix). Instead, subtract the site's own URL from the request URL to get the tail, then append that to the site's content path.